### PR TITLE
Use usingRecursiveFieldByFieldElementComparatorIgnoringFields

### DIFF
--- a/api/src/test/kotlin/com/example/todo/infrastructure/mapper/TaskMapperTest.kt
+++ b/api/src/test/kotlin/com/example/todo/infrastructure/mapper/TaskMapperTest.kt
@@ -70,7 +70,7 @@ internal class TaskMapperTest {
     fun insert() {
         taskMapper.insert(task1)
         assertThat(taskMapper.selectAll(task1.userId))
-            .usingElementComparatorIgnoringFields("registeredAt", "updatedAt")
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("registeredAt", "updatedAt")
             .contains(task1.toEntity(), initialData)
     }
 
@@ -79,7 +79,7 @@ internal class TaskMapperTest {
     fun update() {
         taskMapper.update(task2)
         assertThat(taskMapper.selectAll(task2.userId))
-            .usingElementComparatorIgnoringFields("registeredAt", "updatedAt")
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("registeredAt", "updatedAt")
             .contains(task2.toEntity())
             .doesNotContain(initialData)
     }

--- a/web/src/test/kotlin/com/example/todo/infrastructure/repository/TaskRepositoryImplTest.kt
+++ b/web/src/test/kotlin/com/example/todo/infrastructure/repository/TaskRepositoryImplTest.kt
@@ -76,7 +76,7 @@ internal class TaskRepositoryImplTest {
             )
 
         assertThat(taskRepository.findAll(USER_ID))
-            .usingElementComparatorIgnoringFields("registeredAt", "updatedAt")
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("registeredAt", "updatedAt")
             .contains(task)
         mockRestServiceServer.verify()
     }


### PR DESCRIPTION
Because of having upgraded assetJ  to 3.21.0, usingElementComparatorIgnoringFields have been Deprecated in Java.
Therefore use usingRecursiveFieldByFieldElementComparatorIgnoringFields.